### PR TITLE
fix(docker): docker compose parameters order

### DIFF
--- a/prod1-thehive/scripts/backup.sh
+++ b/prod1-thehive/scripts/backup.sh
@@ -136,7 +136,7 @@ echo "Backup of certificates completed."
 
 ## Restart services
 echo "Restarting services..."
-docker compose up -d -f ${DOCKER_COMPOSE_PATH}/docker-compose.yml
+docker compose up -f ${DOCKER_COMPOSE_PATH}/docker-compose.yml -d
 
 
 


### PR DESCRIPTION
# Description

As explained in [related issue](https://github.com/StrangeBeeCorp/docker/issues/21), there is a disorder of parameters in the docker compose command line.
This PR is simply about correcting that

No special attention required, no limitations, no identified risks other than making the script work again

